### PR TITLE
Make it work in Firefox

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,10 @@ export function download(url, fullName) {
   const anchor = document.createElement('a')
   anchor.href = url
   anchor.setAttribute('download', fullName)
-
-  anchor.click();
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+  window.URL.revokeObjectURL(url)
 }
 
 export default function screenshot(imgNode, format = 'png', quality = 0.97) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ export function download(url, fullName) {
   document.body.appendChild(anchor)
   anchor.click()
   document.body.removeChild(anchor)
-  window.URL.revokeObjectURL(url)
 }
 
 export default function screenshot(imgNode, format = 'png', quality = 0.97) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export function download(url, fullName) {
   const anchor = document.createElement('a')
   anchor.href = url
+  anchor.style.display = 'none'
   anchor.setAttribute('download', fullName)
   document.body.appendChild(anchor)
   anchor.click()


### PR DESCRIPTION
Hey! Awesome library!

Trying to download the image from [css-filter App](https://cyan33.github.io/css-filter/) using _Firefox_ right now it's not possible. However appending the `anchor` before `click` and removing after, lets work properly in _cross-browser_. 

I had to [tweak the same](https://github.com/elrumordelaluz/micro-svg-spreact/commit/4617e8da0f5a65f56a8a4341f78c8e8e871c2e0e#diff-f606ad2265472a3cdd48eb8a47161e98) weeks ago. The discoveries after change my default browser into _Firefox_  :)

#### Current behaviour
![current](https://user-images.githubusercontent.com/784056/54242243-2bf31180-4524-11e9-964f-5c6c25d41e29.gif)

#### After tweaks
![new](https://user-images.githubusercontent.com/784056/54242245-2e556b80-4524-11e9-86c8-7dd6aa83ed7e.gif)

